### PR TITLE
feat: Update dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,21 +19,12 @@
       }
     },
     {
-      "identity" : "cryptoswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
-      "state" : {
-        "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
-        "version" : "1.8.1"
-      }
-    },
-    {
       "identity" : "curvelib.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tkey/curvelib.swift",
       "state" : {
-        "revision" : "7dad3bf1793de263f83406c08c18c9316abf082f",
-        "version" : "0.1.2"
+        "revision" : "9f88bd5e56d1df443a908f7a7e81ae4f4d9170ea",
+        "version" : "1.0.1"
       }
     },
     {
@@ -41,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torusresearch/fetch-node-details-swift.git",
       "state" : {
-        "revision" : "d591af500f32ce3c88d04af9bb74d746585acfea",
-        "version" : "5.1.0"
+        "revision" : "5f67cd080c26cf38ae91e7fe63e6217c6e401c07",
+        "version" : "6.0.2"
       }
     },
     {
@@ -68,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Web3Auth/session-manager-swift.git",
       "state" : {
-        "revision" : "290e36cd0646f7fb3be737b65bdfc9f5428dfd5c",
-        "version" : "3.1.0"
+        "revision" : "20cc7bff065d7fe53164d17e7714a3f17d4cea2a",
+        "version" : "4.0.2"
       }
     },
     {
@@ -86,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torusresearch/torus-utils-swift",
       "state" : {
-        "revision" : "04c62fd5f73f21bd01b7c07e08f6135db26c5940",
-        "version" : "8.0.0"
+        "revision" : "ff85c3e96bfa29013309b487875c4d9383e4ac80",
+        "version" : "8.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,10 @@ let package = Package(
             targets: ["SingleFactorAuth"])
     ],
     dependencies: [
-        .package(url: "https://github.com/torusresearch/fetch-node-details-swift.git", from: "5.1.0"),
-        .package(url: "https://github.com/torusresearch/torus-utils-swift.git", from: "8.0.0"),
+        .package(url: "https://github.com/torusresearch/fetch-node-details-swift.git", from: "6.0.1"),
+        .package(url: "https://github.com/torusresearch/torus-utils-swift.git", from: "8.1.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0"),
-        .package(url: "https://github.com/Web3Auth/session-manager-swift.git", from: "3.1.0")
+        .package(url: "https://github.com/Web3Auth/session-manager-swift.git", from: "4.0.2"),
     ],
     targets: [
         .target(

--- a/SingleFactorAuth.podspec
+++ b/SingleFactorAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "SingleFactorAuth"
-  spec.version      = "4.0.0"
+  spec.version      = "5.0.0"
   spec.ios.deployment_target  = "14.0"
   spec.summary      = "Enable one key flow for Web3Auth"
   spec.homepage     = "https://github.com/Web3Auth/single-factor-auth-swift"

--- a/SingleFactorAuth.podspec
+++ b/SingleFactorAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "SingleFactorAuth"
-  spec.version      = "3.0.0"
+  spec.version      = "4.0.0"
   spec.ios.deployment_target  = "14.0"
   spec.summary      = "Enable one key flow for Web3Auth"
   spec.homepage     = "https://github.com/Web3Auth/single-factor-auth-swift"
@@ -10,7 +10,8 @@ Pod::Spec.new do |spec|
   spec.module_name = "SingleFactorAuth"
   spec.source       = { :git => "https://github.com/web3Auth/single-factor-auth-swift", :tag => spec.version }
   spec.source_files = "Sources/SingleFactorAuth/*.{swift,json}","Sources/SingleFactorAuth/**/*.{swift,json}"
-  spec.dependency 'Torus-fetchNodeDetails', '~> 5.1.0'
-  spec.dependency 'Torus-utils', '~> 6.1.0'
-  spec.dependency 'TorusSessionManager', '~> 3.0.1'
+  spec.dependency 'Torus-fetchNodeDetails', '~> 6.0.1'
+  spec.dependency 'curvelib.swift', '~> 1.0.1'
+  spec.dependency 'Torus-utils', '~> 8.1.0'
+  spec.dependency 'TorusSessionManager', '~> 4.0.2'
 end

--- a/Sources/SingleFactorAuth/SingleFactorAuth.swift
+++ b/Sources/SingleFactorAuth/SingleFactorAuth.swift
@@ -1,10 +1,10 @@
 import BigInt
 import Combine
-import CryptoSwift
 import FetchNodeDetails
 import Foundation
 import SessionManager
 import TorusUtils
+import curveSecp256k1
 
 public class SingleFactorAuth {
     let nodeDetailManager: NodeDetailManager
@@ -16,8 +16,6 @@ public class SingleFactorAuth {
         nodeDetailManager = NodeDetailManager(network: singleFactorAuthArgs.getNetwork().network)
         torusUtils = TorusUtils(
             enableOneKey: true,
-            signerHost: singleFactorAuthArgs.getSignerUrl()! + "/api/sign",
-            allowHost: singleFactorAuthArgs.getSignerUrl()! + "/api/allow",
             network: singleFactorAuthArgs.getNetwork().network,
             clientId: singleFactorAuthArgs.getWeb3AuthClientId()
         )
@@ -65,7 +63,7 @@ public class SingleFactorAuth {
 
             let verifierParams = VerifierParams(verifier_id: loginParams.verifierId)
             
-            let aggregateIdToken =  aggregateIdTokenSeeds.joined(separator: "\u{001d}").bytes.sha3(.keccak256).toHexString()  // drop 0x
+            let aggregateIdToken = try curveSecp256k1.keccak256(data: Data(aggregateIdTokenSeeds.joined(separator: "\u{001d}").utf8)).toHexString()
 
             retrieveSharesResponse = try await torusUtils.retrieveShares(
                 endpoints: details.getTorusNodeEndpoints(),

--- a/Sources/SingleFactorAuth/SingleFactorAuthArgs.swift
+++ b/Sources/SingleFactorAuth/SingleFactorAuthArgs.swift
@@ -1,4 +1,3 @@
-import CommonSources
 import FetchNodeDetails
 import TorusUtils
 

--- a/Tests/SingleFactorAuthTests/AquaTest.swift
+++ b/Tests/SingleFactorAuthTests/AquaTest.swift
@@ -1,5 +1,4 @@
 import BigInt
-import CommonSources
 import JWTKit
 import XCTest
 

--- a/Tests/SingleFactorAuthTests/CyanTest.swift
+++ b/Tests/SingleFactorAuthTests/CyanTest.swift
@@ -1,5 +1,4 @@
 import BigInt
-import CommonSources
 import JWTKit
 import XCTest
 

--- a/Tests/SingleFactorAuthTests/SingleFactorAuthTests.swift
+++ b/Tests/SingleFactorAuthTests/SingleFactorAuthTests.swift
@@ -1,5 +1,4 @@
 import BigInt
-import CommonSources
 import JWTKit
 import XCTest
 


### PR DESCRIPTION
This PR removes cryptoswift from the dependency list as well as updates the podspec.

Note: `jwt-kit` is not published to cocoapods, the updated podspec should work since it currently is only used in tests, however it will break if this no longer becomes the case.

Note: --allow-warnings needs to be passed to publish it. 